### PR TITLE
Recall Image.open after Image.verify

### DIFF
--- a/picopt.py
+++ b/picopt.py
@@ -597,6 +597,7 @@ def get_image_format(filename, arguments):
     try:
         image = Image.open(filename)
         bad_image = image.verify()
+        image = Image.open(filename)
         image_format = image.format
         sequenced = is_image_sequenced(image)
     except (OSError, IOError):


### PR DESCRIPTION
An image has to be reopened after calling verify on it, as documented
here: http://effbot.org/imagingbook/image.htm#tag-Image.Image.verify

Without this, picopt would crash when run on a gif file.
