### PR TITLE
Remove dev dependencies from "prod" requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,3 @@ Pillow
 rarfile
 python-dateutil
 argparse
-
-coverage
-nose
-flake8
-pep8-naming


### PR DESCRIPTION
I noticed some unexpected packages were included after installing picopt. It looks like these are purely development packages already included in `requirements-dev.txt`.