### PR TITLE
Fix entry point so that the cli script runs

### DIFF
--- a/picopt/cli.py
+++ b/picopt/cli.py
@@ -172,8 +172,11 @@ def process_arguments(arguments):
     return arguments
 
 
-def main(args):
+def main(args=None):
     """Process command line arguments and walk inputs."""
+    if args is None:
+        import sys
+        args = sys.argv
     raw_arguments = get_arguments(args[1:])
     process_arguments(raw_arguments)
     walk.run()


### PR DESCRIPTION
Previously, the CLI would always exit with:

```
Traceback (most recent call last):
  File "/Users/ryan/.pyenv/versions/3.5.2/bin/picopt", line 9, in <module>
    load_entry_point('picopt==1.4.0', 'console_scripts', 'picopt')()
TypeError: main() missing 1 required positional argument: 'args'
```

because the setup.py entry point function receives no arguments, and the
main function required one argument. That argument is now optional and
defaults to sys.argv if not provided.
