### PR TITLE
Replace walk/dispatch with futures-based scheduler

### DIFF
--- a/picopt/config/__init__.py
+++ b/picopt/config/__init__.py
@@ -57,6 +57,8 @@ def _build_template() -> MappingTemplate:
                     "disable_programs": Sequence(str),
                     "dry_run": bool,
                     "extra_formats": Optional(Sequence(Choice(all_format_strs))),
+                    "fail_fast": bool,
+                    "fail_fast_container": bool,
                     "formats": Sequence(Choice(all_format_strs)),
                     "ignore": Sequence(str),
                     "ignore_defaults": bool,

--- a/picopt/config_default.yaml
+++ b/picopt/config_default.yaml
@@ -4,6 +4,8 @@ picopt:
   convert_to: []
   disable_programs: []
   dry_run: False
+  fail_fast: False
+  fail_fast_container: False
   formats: [GIF, JPEG, PNG, WEBP]
   ignore: []
   ignore_defaults: True

--- a/picopt/plugins/base/archive.py
+++ b/picopt/plugins/base/archive.py
@@ -178,7 +178,7 @@ class ArchiveHandler(ContainerHandler, ABC):
                 data := self._archive_readfile(archive, archiveinfo.info)
             ):
                 path_info.set_data(data)
-            self.set_task(path_info, None)
+            self._optimized_contents.add(path_info)
 
     @override
     def walk(self) -> Generator[PathInfo]:
@@ -189,22 +189,18 @@ class ArchiveHandler(ContainerHandler, ABC):
             for archiveinfo in non_treestamp_entries:
                 if path_info := self._walk_one_entry(archive, archiveinfo):
                     yield path_info
-            if self._do_repack:
-                self._copy_unchanged_files(archive)
+            # Always copy unchanged files: the scheduler decides
+            # whether to repack after children are processed, but
+            # we must read data while the archive is still open.
+            self._copy_unchanged_files(archive)
         self._walk_finish()
 
     @override
-    def _hydrate_optimized_path_info(
+    def hydrate_optimized_path_info(
         self, path_info: PathInfo, report: ReportStats
     ) -> None:
-        super()._hydrate_optimized_path_info(path_info, report)
+        super().hydrate_optimized_path_info(path_info, report)
         original_path = path_info.name()
         final_path = report.path
         if final_path and original_path != final_path:
             path_info.rename(final_path)
-            self._do_repack = True
-
-    @override
-    def optimize_contents(self) -> None:
-        super().optimize_contents()
-        self._skip_path_infos = set()

--- a/picopt/plugins/base/container.py
+++ b/picopt/plugins/base/container.py
@@ -32,8 +32,6 @@ from picopt.plugins.base.handler import Handler
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-    from multiprocessing.pool import ApplyResult
-
     from confuse import AttrDict
     from treestamps import Grovestamps
 
@@ -70,7 +68,6 @@ class ContainerHandler(Handler, ABC):
             self.config, self._printer, timestamps, in_archive=True
         )
         self.comment: bytes | None = comment
-        self._tasks: dict[PathInfo, ApplyResult] = {}
         self._optimized_contents: set[PathInfo] = optimized_contents or set()
         self._do_repack: bool = bool(optimized_contents)
 
@@ -99,28 +96,16 @@ class ContainerHandler(Handler, ABC):
         """Set the flag determining whether the container needs repack."""
         self._do_repack = do_repack
 
-    def set_task(self, path_info: PathInfo, mp_result: ApplyResult | None) -> None:
-        """Store the multiprocessing result for one child path."""
-        if mp_result is None:
-            self._optimized_contents.add(path_info)
-            self._printer.copied()
-        else:
-            self._tasks[path_info] = mp_result
-            self._do_repack = True
-
-    def _hydrate_optimized_path_info(
+    def hydrate_optimized_path_info(
         self, path_info: PathInfo, report: ReportStats
     ) -> None:
+        """Pull optimized bytes from a completed report back onto path_info.
+
+        Subclasses (archive, PDF) override to handle renames.
+        Called by the scheduler after each leaf completes.
+        """
         if report.data:
             path_info.set_data(report.data)
-
-    def optimize_contents(self) -> None:
-        """Collect every queued multiprocessing result, then strip non-pickleables."""
-        for path_info in tuple(self._tasks):
-            mp_results = self._tasks.pop(path_info)
-            report = mp_results.get()
-            self._hydrate_optimized_path_info(path_info, report)
-            self._optimized_contents.add(path_info)
 
     def get_optimized_contents(self) -> set[PathInfo]:
         """Return optimized contents."""

--- a/picopt/plugins/pdf.py
+++ b/picopt/plugins/pdf.py
@@ -447,7 +447,7 @@ class Pdf(ContainerHandler):
     # ------------------------------------------------------------ hydration
 
     @override
-    def _hydrate_optimized_path_info(
+    def hydrate_optimized_path_info(
         self, path_info: PathInfo, report: ReportStats
     ) -> None:
         """

--- a/picopt/walk/init.py
+++ b/picopt/walk/init.py
@@ -1,6 +1,6 @@
 """Walk initialization."""
 
-from multiprocessing.pool import Pool
+from concurrent.futures import ProcessPoolExecutor
 from typing import TYPE_CHECKING
 
 from confuse.templates import AttrDict
@@ -45,7 +45,9 @@ class WalkInit:
         self._validate_top_paths()
         self._printer: Printer = Printer(config.verbose)
         self._totals: Totals = Totals(config, self._printer)
-        self._pool: Pool = Pool(self._config.jobs) if self._config.jobs else Pool()
+        self._executor: ProcessPoolExecutor = ProcessPoolExecutor(
+            max_workers=self._config.jobs or None
+        )
         self._timestamps: Grovestamps | None = None  # reassigned at start of run
         self._skipper: WalkSkipper = WalkSkipper(config, self._printer)
 

--- a/picopt/walk/scheduler.py
+++ b/picopt/walk/scheduler.py
@@ -160,7 +160,7 @@ Job = UnpackJob | OptimizeLeafJob | RepackJob
 # --------------------------------------------------------------------- nodes
 
 
-@dataclass
+@dataclass(eq=False)
 class ContainerNode:
     """Bookkeeping for one container in the job tree."""
 
@@ -432,8 +432,9 @@ class Scheduler:
                 parent.pending = max(0, parent.pending - 1)
                 return
             if report.exc is None:
-                if report.data:
-                    entry.job.path_info.set_data(report.data)
+                parent.handler.hydrate_optimized_path_info(
+                    entry.job.path_info, report
+                )
                 parent.handler.get_optimized_contents().add(entry.job.path_info)
                 if report.changed:
                     parent.had_work = True
@@ -450,12 +451,12 @@ class Scheduler:
         self._write_timestamp(report, entry.job.path_info.top_path)
 
     def _handle_repack_failure(self, report, node):
-        if self._config.get("fail_fast"):
+        if self._config.fail_fast:
             self._totals.errors.append(report)
             report.report(self._printer)
             self._trigger_fail_fast(report.exc)
             return
-        if self._config.get("fail_fast_container"):
+        if self._config.fail_fast_container:
             # escalate to top-level container of this subtree
             root = node
             while root.parent is not None:
@@ -519,7 +520,13 @@ class Scheduler:
         if node.state is NodeState.REPACKING or node.state is NodeState.DONE:
             return
 
-        node.handler.set_do_repack(do_repack=node.had_work)
+        # Respect the handler's own _do_repack flag (set during walk) OR
+        # whether any child produced replacement bytes. Handlers like
+        # Img2WebPAnimated set _do_repack=True unconditionally during walk()
+        # because format conversion always requires repacking even when no
+        # individual child was "optimized".
+        if not node.handler.is_do_repack():
+            node.handler.set_do_repack(do_repack=node.had_work)
         if not node.handler.is_do_repack():
             # No work: synthesize a no-op completion so the parent chain
             # gets notified identically to a real repack.

--- a/picopt/walk/walk.py
+++ b/picopt/walk/walk.py
@@ -1,7 +1,7 @@
 """Walk the directory trees and files and call the optimizers."""
 
+import os
 import traceback
-from multiprocessing.pool import ApplyResult, AsyncResult
 from pathlib import Path
 
 from treestamps import Treestamps
@@ -10,43 +10,35 @@ from picopt.path import PathInfo
 from picopt.plugins.base import ContainerHandler, Handler, ImageHandler
 from picopt.report import ReportStats, Totals
 from picopt.walk.handler_factory import HandlerFactory
+from picopt.walk.scheduler import ContainerNode, OptimizeLeafJob, Scheduler
 
 
 class Walk(HandlerFactory):
     """Methods for walking the tree and handling files."""
 
-    def _finish_results(
-        self,
-        results: list[ApplyResult],
-        top_path: Path,
+    def _enqueue_children(
+        self, sched: Scheduler, node: ContainerNode, children: list[PathInfo]
     ) -> None:
-        """
-        Get the async results and total them.
+        """Bridge between scheduler and HandlerFactory for container children."""
+        for path_info in children:
+            handler = self._create_handler(path_info)
+            if handler is None:
+                # noop copy — child passes through unmodified
+                node.handler.get_optimized_contents().add(path_info)
+                continue
+            if isinstance(handler, ContainerHandler):
+                sched.enqueue_container(handler, parent=node)
+            elif isinstance(handler, ImageHandler):
+                sched.enqueue_leaf(
+                    OptimizeLeafJob(handler=handler, path_info=path_info),
+                    parent=node,
+                )
 
-        Returns weather timestamps should be dumped or not
-        """
-        for result in results:
-            final_result = result.get()
-            if final_result.exc:
-                final_result.report(self._printer)
-
-                self._totals.errors.append(final_result)
-            else:
-                self._totals.bytes_in += final_result.bytes_in
-                if final_result.saved > 0 and not self._config.bigger:
-                    self._totals.bytes_out += final_result.bytes_out
-                else:
-                    self._totals.bytes_out += final_result.bytes_in
-            if self._timestamps and final_result.changed:
-                self._timestamps.set(top_path, final_result.path)
-
-    def walk_dir(self, dir_path_info: PathInfo) -> None:
-        """Recursively optimize a directory."""
+    def walk_dir(self, dir_path_info: PathInfo, scheduler: Scheduler) -> None:
+        """Recursively walk a directory, enqueuing jobs into the scheduler."""
         if not self._config.recurse or not dir_path_info.is_dir():
-            # Skip
             return
 
-        results = []
         files = []
         dir_path = dir_path_info.path
 
@@ -58,7 +50,7 @@ class Walk(HandlerFactory):
                         path_info=dir_path_info,
                         path=entry_path,
                     )
-                    self.walk_file(path_info)
+                    self.walk_file(path_info, scheduler)
                 else:
                     files.append(entry_path)
 
@@ -67,56 +59,19 @@ class Walk(HandlerFactory):
                 path_info=dir_path_info,
                 path=entry_path,
             )
-            if result := self.walk_file(path_info):
-                results.append(result)
+            self.walk_file(path_info, scheduler)
 
-        self._finish_results(
-            results,
-            dir_path_info.top_path,
-        )
-
-        if self._timestamps and dir_path:
-            # Compact timestamps after every directory completes
-            self._timestamps.compact(dir_path_info.top_path, dir_path)
-
-    def _walk_container(self, unpack_handler: ContainerHandler) -> None:
-        """Walk the container."""
-        for path_info in unpack_handler.walk():
-            container_result = None
-            if handler := self._create_handler(path_info):
-                container_result = self._handle_file(handler)
-            unpack_handler.set_task(path_info, container_result)
-
-    def _handle_container(self, handler: ContainerHandler) -> ApplyResult | None:
-        """Optimize a container."""
-        result: ApplyResult | None = None
-        try:
-            # Walk and Unpack or Skip
-            self._walk_container(handler)
-            if not handler.is_do_repack():
-                return result
-            # Optimize
-            handler.optimize_contents()
-            # Repack
-            handler.clean_for_repack()
-            handler = self.create_repack_handler(self._config, handler)
-            result = self._pool.apply_async(handler.repack)
-        except Exception as exc:
-            traceback.print_exc()
-            args = (exc,)
-            result = self._pool.apply_async(handler.error, args=args)
-        return result
-
-    def _handle_file(self, handler) -> None | AsyncResult:
-        """Call the correct walk or pool apply for the handler."""
-        if not handler:
-            return None
+    def _handle_file(
+        self, handler: Handler, path_info: PathInfo, scheduler: Scheduler
+    ) -> None:
+        """Enqueue the correct job for the handler type."""
         match handler:
             case ContainerHandler():
-                # Unpack inline, not in the pool, and walk immediately like dirs.
-                return self._handle_container(handler)
+                scheduler.enqueue_container(handler)
             case ImageHandler():
-                return self._pool.apply_async(handler.optimize_wrapper)
+                scheduler.enqueue_leaf(
+                    OptimizeLeafJob(handler=handler, path_info=path_info),
+                )
             case _:
                 msg = f"Bad picopt handler {handler}"
                 raise TypeError(msg)
@@ -131,13 +86,16 @@ class Walk(HandlerFactory):
 
         return handler
 
-    def _walk_file_get_handler(self, path_info: PathInfo) -> Handler | None:
+    def _walk_file_get_handler(
+        self, path_info: PathInfo, scheduler: Scheduler
+    ) -> Handler | None:
         if path_info.frame is None:
             if self._skipper.is_walk_file_skip(path_info):
                 return None
 
             if path_info.is_dir():
-                return self.walk_dir(path_info)
+                self.walk_dir(path_info, scheduler)
+                return None
 
             if self._skipper.is_older_than_timestamp(path_info):
                 return None
@@ -147,54 +105,58 @@ class Walk(HandlerFactory):
             self._printer.skip("no handler", path_info)
         return handler
 
-    def walk_file(self, path_info: PathInfo) -> ApplyResult | None:
-        """Optimize an individual file."""
+    def walk_file(self, path_info: PathInfo, scheduler: Scheduler) -> None:
+        """Optimize an individual file by enqueuing into the scheduler."""
         try:
-            result = None
-            if handler := self._walk_file_get_handler(path_info):
-                result = self._handle_file(handler)
+            if handler := self._walk_file_get_handler(path_info, scheduler):
+                self._handle_file(handler, path_info, scheduler)
         except Exception as exc:
             traceback.print_exc()
-            apply_kwargs = {
-                "path": path_info.path,
-                "bytes_in": path_info.bytes_in(),
-                "exc": exc,
-                "config": self._config,
-                "path_info": path_info,
-            }
-            result = self._pool.apply_async(ReportStats, (), apply_kwargs)
-        return result
+            report = ReportStats(
+                path=path_info.path,
+                bytes_in=path_info.bytes_in(),
+                exc=exc,
+                config=self._config,
+                path_info=path_info,
+            )
+            scheduler.accept_prebuilt_report(report, path_info.top_path)
 
-    def _walk_top_path(self, top_path: Path, top_results: dict):
+    def _walk_top_path(self, top_path: Path, scheduler: Scheduler) -> None:
         dirpath = Treestamps.get_dir(top_path)
         path_info = PathInfo(
             top_path=dirpath, convert=True, path=top_path, is_case_sensitive=None
         )
-        result = self.walk_file(path_info)
-        if dirpath not in top_results:
-            top_results[dirpath] = []
-        if result is not None:
-            top_results[dirpath].append(result)
+        self.walk_file(path_info, scheduler)
 
     def walk(self) -> Totals:
         """Optimize all configured files."""
         self._init_timestamps()
 
-        # Walk each top file
-        top_results = {}
-        for top_path in self._top_paths:
-            self._walk_top_path(top_path, top_results)
-        # Finish
-        for dirpath, results in top_results.items():
-            self._finish_results(results, dirpath)
+        max_workers = self._config.jobs or os.cpu_count() or 1
+        scheduler = Scheduler(
+            config=self._config,
+            executor=self._executor,
+            timestamps=self._timestamps,
+            totals=self._totals,
+            printer=self._printer,
+            max_workers=max_workers,
+            create_repack_handler=self.create_repack_handler,
+            child_enqueue_callback=self._enqueue_children,
+        )
 
-        # Shut down multiprocessing
-        self._pool.close()
-        self._pool.join()
+        for top_path in self._top_paths:
+            self._walk_top_path(top_path, scheduler)
+
+        scheduler.run()
+
+        self._executor.shutdown(wait=True)
 
         self._printer.done()
 
         if self._timestamps:
+            for top_path in self._top_paths:
+                dirpath = Treestamps.get_dir(top_path)
+                self._timestamps.compact(dirpath, dirpath)
             self._timestamps.dumpf()
 
         self._totals.report()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "python-dateutil~=2.8",
   "rarfile~=4.0",
   "ruamel-yaml>=0.18,<1.0",
-  "treestamps~=2.5.1",
+  "treestamps~=2.5.2",
   "typing-extensions~=4.13",
 ]
 description = "A multi format lossless image optimizer that uses external tools"

--- a/uv.lock
+++ b/uv.lock
@@ -1659,7 +1659,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = "~=2.8" },
     { name = "rarfile", specifier = "~=4.0" },
     { name = "ruamel-yaml", specifier = ">=0.18,<1.0" },
-    { name = "treestamps", specifier = "~=2.5.1" },
+    { name = "treestamps", specifier = "~=2.5.2" },
     { name = "typing-extensions", specifier = "~=4.13" },
 ]
 
@@ -2671,16 +2671,16 @@ wheels = [
 
 [[package]]
 name = "treestamps"
-version = "2.5.1"
+version = "2.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ruamel-yaml" },
     { name = "termcolor" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/34/ecb2f42bc17f14301ab2eff371c480df5a063f50d1ca88d90a8960d7ccef/treestamps-2.5.1.tar.gz", hash = "sha256:3dd61e368542ee7e99f97f208aa55949afd485abe6d7124bb4621e60af449318", size = 180816, upload-time = "2026-04-10T02:20:45.704Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/10/e6ceface39ec2a2b1814cb64e02b5734c74cecc41b3811bae8bb26c9b7ab/treestamps-2.5.2.tar.gz", hash = "sha256:41f7088b4a84f88acf70d1e97328825c9b7e4d581249270c5af7938f3e644a0d", size = 181038, upload-time = "2026-04-10T23:06:19.762Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/2c/8920151517d1eac794d55cddde88b04e90a79f67b4750b1bfd091f992d12/treestamps-2.5.1-py3-none-any.whl", hash = "sha256:f6a105e0bac38a032d2faf1b02d28b1eacf30fb2bdebb12029990f0b8c1e1e48", size = 15269, upload-time = "2026-04-10T02:20:44.491Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/98/a73f55e9af2c8793985d865f8862a5c5e62ed7da9e45d4041f938c46e5b1/treestamps-2.5.2-py3-none-any.whl", hash = "sha256:a47d44267460285e5cf13ec5f9267c5da72f71e522ff26930ffcb530917068c1", size = 15375, upload-time = "2026-04-10T23:06:20.67Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace `multiprocessing.pool.Pool` with `concurrent.futures.ProcessPoolExecutor` and route all work through a new `Scheduler` class that manages a `ContainerNode` tree with three job types (Unpack, OptimizeLeaf, Repack), backpressure (2x max_workers cap), and per-node failure rollback
- Delete serial `_finish_results`, recursive `_handle_container`/`_walk_container`, and `optimize_contents` barrier — the scheduler's main-thread loop with `wait(FIRST_COMPLETED)` keeps every worker busy on archive-heavy trees
- Add `fail_fast` and `fail_fast_container` config options for controlling error propagation behavior
- Bump `treestamps>=2.5.2` for pickleable `GrovestampsConfig`

## Files changed
- `picopt/walk/scheduler.py` — new scheduler with ContainerNode tree, three job types, backpressure, rollback
- `picopt/walk/walk.py` — rewritten to enqueue jobs into scheduler instead of managing pool directly
- `picopt/walk/init.py` — Pool → ProcessPoolExecutor
- `picopt/plugins/base/container.py` — removed `set_task`/`optimize_contents`/`_tasks`; public `hydrate_optimized_path_info`
- `picopt/plugins/base/archive.py` — adapted to new API, always copies unchanged files during walk
- `picopt/plugins/pdf.py` — renamed hydrate method
- `picopt/config/__init__.py` + `picopt/config_default.yaml` — fail_fast config fields
- `pyproject.toml` — treestamps version bump

## Test plan
- [x] Full test suite passes (150 passed, 6 skipped)
- [ ] Manual test against a real comics library for wall-clock comparison
- [ ] Future: add tests for nested container parallel verification, REPACK-raises rollback, 10k-leaf backpressure

🤖 Generated with [Claude Code](https://claude.com/claude-code)