### PR TITLE
Add --fail-fast and --fail-fast-container CLI options

### DIFF
--- a/picopt/cli.py
+++ b/picopt/cli.py
@@ -333,6 +333,18 @@ def get_arguments(params: tuple[str, ...] | None = None) -> Namespace:
         help="Disable a comma delineated list of external programs.",
     )
     parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        dest="fail_fast",
+        help="Stop all optimization on the first error encountered.",
+    )
+    parser.add_argument(
+        "--fail-fast-container",
+        action="store_true",
+        dest="fail_fast_container",
+        help="When an inner repack fails, fail the entire top-level container.",
+    )
+    parser.add_argument(
         "-V",
         "--version",
         action="version",


### PR DESCRIPTION
## Summary
- Add `--fail-fast` CLI flag to stop all optimization on the first error encountered
- Add `--fail-fast-container` CLI flag to fail the entire top-level container when an inner repack fails

These expose the two scheduler failure modes added in #101 as command-line options.

## Test plan
- [x] Full test suite passes (150 passed, 6 skipped)
- [x] Both flags appear in `picopt --help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)