### PR TITLE
Fix BufferedReader pickling error when timestamps file exists

### DIFF
--- a/picopt/plugins/base/container.py
+++ b/picopt/plugins/base/container.py
@@ -145,6 +145,13 @@ class ContainerHandler(Handler, ABC):
         self._timestamps = None
         self._skipper = None
 
+    def __getstate__(self) -> dict[str, Any]:
+        """Drop Grovestamps for worker handoff; its ruamel.yaml Reader owns an un-picklable BufferedReader."""
+        state = self.__dict__.copy()
+        state["_timestamps"] = None
+        state["_skipper"] = None
+        return state
+
     def repack(self) -> ReportStats:
         """Public alias used by the multiprocessing pool dispatcher."""
         return self.optimize_wrapper()

--- a/picopt/plugins/base/container.py
+++ b/picopt/plugins/base/container.py
@@ -140,11 +140,6 @@ class ContainerHandler(Handler, ABC):
         self._printer.container_repacking_done()
         return buffer
 
-    def clean_for_repack(self) -> None:
-        """Wipe state that doesn't pickle or aren't needed for multiprocessing repack."""
-        self._timestamps = None
-        self._skipper = None
-
     def __getstate__(self) -> dict[str, Any]:
         """Drop Grovestamps for worker handoff; its ruamel.yaml Reader owns an un-picklable BufferedReader."""
         state = self.__dict__.copy()

--- a/picopt/walk/scheduler.py
+++ b/picopt/walk/scheduler.py
@@ -587,7 +587,6 @@ class Scheduler:
             self._handle_repack_done(node, noop)
             return
 
-        node.handler.clean_for_repack()
         repack_handler = self._create_repack_handler(self._config, node.handler)
         node.handler = repack_handler
         self._ready.append((RepackJob(handler=repack_handler), node))


### PR DESCRIPTION
## Summary

- Fixes `TypeError: cannot pickle 'BufferedReader' instances` when picopt runs with `-t` (timestamps) over files whose parent already has a `.picopt_treestamps.yaml` from a prior run. Reported against `picopt -rtvx EPUB,PDF /Volumes/Media/Backup/Books`; every archive raises and skips.
- Root cause: `Grovestamps.loadf_tree()` calls `ruamel.yaml.YAML().load(file)`, which leaves the YAML instance holding a `Reader` with an open `BufferedReader`. That Grovestamps is attached to every `ArchiveHandler` as `_timestamps` (and referenced again via `_skipper`). When the scheduler submits `UnpackJob`/`RepackJob` to the `ProcessPoolExecutor`, pickling walks into the `BufferedReader` and aborts.
- Fix: add `__getstate__` on `ContainerHandler` that nulls `_timestamps` and `_skipper` at pickle time. The scheduler owns the real Grovestamps on the main thread; workers never meaningfully used the handler's copy (in-archive timestamp consumption mutated a pickled copy whose mutations never propagated back).

## Test plan

- [x] Reproduction: `cp some.epub /tmp/r/; picopt -rtvx EPUB,PDF /tmp/r/; touch /tmp/r/some.epub; picopt -rtvx EPUB,PDF /tmp/r/` — fails before the patch, succeeds after.
- [x] `make fix` / `make lint` clean.
- [x] `make typecheck` clean.
- [x] `make test` — 150 passed, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)