### PR TITLE
Pre-walk file count for a determinate progress bar

### DIFF
--- a/picopt/log/progress.py
+++ b/picopt/log/progress.py
@@ -178,6 +178,7 @@ def make_progress(
     console: Console,
     *,
     enabled: bool = True,
+    total: int | None = None,
     description: str = "Optimizing",
 ) -> ProgressContext:
     """Build a ProgressContext, or a no-op when disabled / not a terminal."""
@@ -203,5 +204,5 @@ def make_progress(
         console=console,
         transient=False,
     )
-    task_id = progress.add_task(description, total=None)
+    task_id = progress.add_task(description, total=total)
     return ProgressContext(progress, char_column, task_id, enabled=True)

--- a/picopt/walk/walk.py
+++ b/picopt/walk/walk.py
@@ -213,6 +213,41 @@ class Walk:
         )
         self.walk_file(path_info, scheduler)
 
+    def _count(
+        self, path: Path, name: str, *, is_symlink: bool, is_dir: bool
+    ) -> int:
+        """
+        Count progress-bar advances for ``path``.
+
+        Pre-resolved ``is_symlink`` / ``is_dir`` come from ``os.scandir`` on
+        recursive calls so deep trees don't pay an extra ``stat`` per entry.
+        """
+        if (
+            not self._config.recurse
+            or (not self._config.symlinks and is_symlink)
+            or name in WalkSkipper._TIMESTAMPS_FILENAMES  # noqa: SLF001
+            or not is_dir
+            or is_path_ignored(self._config, path, ignore_case=False)
+        ):
+            return 1
+        try:
+            with os.scandir(path) as it:
+                entries = sorted(it, key=lambda e: e.name)
+        except OSError:
+            return 1
+        total = 0
+        for entry in entries:
+            try:
+                total += self._count(
+                    Path(entry.path),
+                    entry.name,
+                    is_symlink=entry.is_symlink(),
+                    is_dir=entry.is_dir(),
+                )
+            except OSError:
+                total += 1
+        return total
+
     def _count_path(self, path: Path) -> int:
         """
         Mirror walk_file's recursion gate to count progress-bar advances.
@@ -224,19 +259,14 @@ class Walk:
         so they're not counted.
         """
         try:
-            recurse = (
-                self._config.recurse
-                and (self._config.symlinks or not path.is_symlink())
-                and path.name not in WalkSkipper._TIMESTAMPS_FILENAMES  # noqa: SLF001
-                and not is_path_ignored(self._config, path, ignore_case=False)
-                and path.is_dir()
+            return self._count(
+                path,
+                path.name,
+                is_symlink=path.is_symlink(),
+                is_dir=path.is_dir(),
             )
-            if not recurse:
-                return 1
-            entries = sorted(path.iterdir())
         except OSError:
             return 1
-        return sum(self._count_path(child) for child in entries)
 
     def _count_total(self) -> int:
         """Total advance count for the progress bar across all top paths."""

--- a/picopt/walk/walk.py
+++ b/picopt/walk/walk.py
@@ -19,7 +19,7 @@ from picopt.log.progress import make_progress
 from picopt.log.reporter import Reporter
 from picopt.log.summary import Stats
 from picopt.log.summary import render as render_summary
-from picopt.path import PathInfo
+from picopt.path import PathInfo, is_path_ignored
 from picopt.plugins.base import ContainerHandler, Handler, ImageHandler
 from picopt.report import ReportStats
 from picopt.walk.handler_factory import HandlerFactory
@@ -213,12 +213,44 @@ class Walk:
         )
         self.walk_file(path_info, scheduler)
 
+    def _count_path(self, path: Path) -> int:
+        """
+        Mirror walk_file's recursion gate to count progress-bar advances.
+
+        Each non-recursing visit produces one progress mark — top-level
+        files, ignored/symlink/timestamp-file dirs, and so on. Recursed
+        directories contribute their children's counts instead. In-archive
+        children don't emit marks (workers can't reach the live region),
+        so they're not counted.
+        """
+        try:
+            recurse = (
+                self._config.recurse
+                and (self._config.symlinks or not path.is_symlink())
+                and path.name not in WalkSkipper._TIMESTAMPS_FILENAMES  # noqa: SLF001
+                and not is_path_ignored(self._config, path, ignore_case=False)
+                and path.is_dir()
+            )
+            if not recurse:
+                return 1
+            entries = sorted(path.iterdir())
+        except OSError:
+            return 1
+        return sum(self._count_path(child) for child in entries)
+
+    def _count_total(self) -> int:
+        """Total advance count for the progress bar across all top paths."""
+        return sum(self._count_path(top) for top in self._top_paths)
+
     def walk(self) -> Stats:
         """Optimize all configured files."""
         self._init_timestamps()
 
         max_workers = self._config.jobs or os.cpu_count() or 1
-        progress = make_progress(console, enabled=self._config.verbose > 0)
+        total = self._count_total()
+        progress = make_progress(
+            console, enabled=self._config.verbose > 0, total=total
+        )
         # Replace the no-op progress that the skipper / factory captured at
         # construction time so they advance the real bar.
         self._reporter.progress = progress


### PR DESCRIPTION
## Summary

Follow-up to [#109](https://github.com/ajslater/picopt/pull/109): the new logger's progress bar was indeterminate (no `M/N`, no percentage) because there was no pre-walk count.

Add `Walk._count_total()` that mirrors `walk_file`'s recursion gate (symlinks, timestamp filenames, ignore patterns, `recurse` flag) so each non-recursing visit contributes exactly one mark — matching the events the scheduler dispatches through `Reporter` — and pass it as `total=` to `make_progress`.

## Test plan

- [x] `uv run ruff check picopt/` — clean
- [x] `uv run basedpyright picopt/walk/walk.py picopt/log/progress.py` — 0 errors / 0 warnings
- [x] `uv run pytest --deselect tests/test_timestamps.py::TestTimestamps::test_timestamp_parents` — 149 passed (the deselected test is a pre-existing treestamps v4 issue, unrelated)
- [x] Verified `Walk._count_total()` returns `3` for a directory with `a.jpg`, `b.jpg`, `sub/c.jpg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)