### PR TITLE
Log timestamp load/dump and surface INFO at default verbose=1

### DIFF
--- a/picopt/log/__init__.py
+++ b/picopt/log/__init__.py
@@ -27,11 +27,13 @@ __all__ = ("console", "logger", "setup")
 console: Final[Console] = Console(highlight=False)
 
 
-# verbose -> minimum loguru level to emit
+# verbose -> minimum loguru level to emit. Picopt's default verbose is 1,
+# and the old termcolor Printer showed config-style messages
+# (force_verbose=True) at that level — so INFO must be visible at verbose=1
+# or those regress to silent.
 _VERBOSE_LEVEL: Final = {
     0: "ERROR",
-    1: "WARNING",
-    2: "INFO",
+    1: "INFO",
 }
 
 

--- a/picopt/walk/walk.py
+++ b/picopt/walk/walk.py
@@ -87,10 +87,20 @@ class Walk:
             program_config=self._config,
             program_config_keys=TIMESTAMPS_CONFIG_KEYS,
         )
+        roots = ", ".join(str(p) for p in self._top_paths)
+        logger.info(f"Loading timestamps for: {roots}")
         self._timestamps = Grovestamps(config)
         for timestamps in self._timestamps.values():
             OldTimestamps(self._config, timestamps).import_old_timestamps()
         self._skipper.set_timestamps(self._timestamps)
+
+    def _dump_timestamps(self) -> None:
+        """Dump timestamps to disk, with a log line per top path."""
+        if not self._timestamps:
+            return
+        roots = ", ".join(str(p) for p in self._timestamps)
+        logger.info(f"Dumping timestamps for: {roots}")
+        self._timestamps.dumpf()
 
     def _enqueue_children(
         self, sched: Scheduler, node: ContainerNode, children: list[PathInfo]
@@ -303,8 +313,7 @@ class Walk:
 
             self._executor.shutdown(wait=True)
 
-        if self._timestamps:
-            self._timestamps.dumpf()
+        self._dump_timestamps()
 
         if self._config.verbose > 0:
             render_summary(self._stats, console, dry_run=bool(self._config.dry_run))


### PR DESCRIPTION
## Summary

Treestamps 4 dropped its own load/dump prints, and picopt's new logger mapped INFO to verbose>=2 — so default runs went silent for messages the old termcolor `Printer` always showed (the `force_verbose=True` tier: config lines, scan-archive, etc).

- `picopt/log/__init__.py`: bump `_VERBOSE_LEVEL` so the argparse default `verbose=1` emits INFO. This restores the old printer's force-verbose tier.
- `picopt/walk/walk.py`: add `Loading timestamps for: …` before `Grovestamps(...)` init and `Dumping timestamps for: …` before `dumpf()`. Both render cyan via the existing `LEVEL_STYLES` mapping for INFO.

## Test plan

- [x] `uv run ruff check picopt/` — clean
- [x] `uv run pytest --deselect tests/test_timestamps.py::TestTimestamps::test_timestamp_parents` — 149 passed (the deselected test is a pre-existing treestamps v4 issue)
- [x] Smoke-tested `picopt -t /tmp/dir`: both `Loading timestamps for: …` and `Dumping timestamps for: …` show at the default verbosity, in cyan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)