### PR TITLE
Migrate to confuse 2.2.0 by replacing AttrDict with PicoptSettings

### DIFF
--- a/picopt/config/__init__.py
+++ b/picopt/config/__init__.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import re
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from confuse import Configuration, MappingTemplate
 from confuse.templates import (
@@ -31,6 +31,11 @@ from loguru import logger
 from picopt import PROGRAM_NAME
 from picopt import plugins as registry
 from picopt.config.handlers import ConfigHandlers
+from picopt.config.settings import (
+    ComputedSettings,
+    IgnorePatterns,
+    PicoptSettings,
+)
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -194,8 +199,8 @@ class PicoptConfig(ConfigHandlers):
 
     def get_config(
         self, args: Namespace | None = None, modname: str = PROGRAM_NAME
-    ) -> AttrDict:
-        """Get the config dict, layering env and args over defaults."""
+    ) -> PicoptSettings:
+        """Get the validated, frozen settings layered from defaults/env/args."""
         config = Configuration(PROGRAM_NAME, modname=modname, read=False)
         config.read()
         if args and getattr(args, "picopt", None) and args.picopt.config:
@@ -209,4 +214,51 @@ class PicoptConfig(ConfigHandlers):
         self._set_timestamps(config_program)
         self.set_format_handler_map(config_program)
         ad = config.get(_build_template())
-        return ad.picopt
+        if not isinstance(ad, AttrDict):
+            msg = f"Expected AttrDict from confuse, got {type(ad).__name__}"
+            raise TypeError(msg)
+        return _settings_from_attrdict(ad.picopt)
+
+
+def _settings_from_attrdict(ad: Any) -> PicoptSettings:
+    """
+    Build a frozen :class:`PicoptSettings` from a validated AttrDict.
+
+    Confuse's ``MappingTemplate`` already normalized the leaf types, but
+    confuse 2.2.0's typed ``AttrDict[str, object]`` widens every attribute
+    read back to ``object``. ``ad`` is typed as ``Any`` here so this
+    conversion — the one place that knows the schema — can read fields
+    directly. Downstream code consumes the typed ``PicoptSettings`` only.
+    """
+    computed = ad.computed
+    ignore = computed.ignore
+    return PicoptSettings(
+        after=ad.after,
+        bigger=ad.bigger,
+        convert_to=tuple(ad.convert_to) if ad.convert_to is not None else None,
+        disable_programs=tuple(ad.disable_programs),
+        dry_run=ad.dry_run,
+        extra_formats=tuple(ad.extra_formats) if ad.extra_formats is not None else None,
+        fail_fast=ad.fail_fast,
+        fail_fast_container=ad.fail_fast_container,
+        formats=tuple(ad.formats),
+        ignore=tuple(ad.ignore),
+        ignore_defaults=ad.ignore_defaults,
+        jobs=ad.jobs,
+        keep_metadata=ad.keep_metadata,
+        list_only=ad.list_only,
+        near_lossless=ad.near_lossless,
+        paths=tuple(ad.paths),
+        png_max=ad.png_max,
+        preserve=ad.preserve,
+        recurse=ad.recurse,
+        symlinks=ad.symlinks,
+        timestamps=ad.timestamps,
+        timestamps_check_config=ad.timestamps_check_config,
+        timestamps_ignore_archive_entry_mtimes=ad.timestamps_ignore_archive_entry_mtimes,
+        verbose=ad.verbose,
+        computed=ComputedSettings(
+            handler_stages=dict(computed.handler_stages),
+            ignore=IgnorePatterns(case=ignore.case, ignore_case=ignore.ignore_case),
+        ),
+    )

--- a/picopt/config/settings.py
+++ b/picopt/config/settings.py
@@ -1,0 +1,101 @@
+"""
+Typed runtime config for picopt.
+
+Confuse 2.2.0 made ``AttrDict`` a proper generic; an unparameterized
+``AttrDict`` resolves to ``AttrDict[str, object]``, and downstream sites
+like ``bool(cfg.flag)`` or ``int(cfg.workers)`` no longer type-check.
+
+The fix is to stop passing ``AttrDict`` around. ``confuse`` still parses
+YAML / env vars / CLI overrides and validates types via ``MappingTemplate``;
+the validated result is converted into this dataclass once in
+:meth:`PicoptConfig.get_config`. Every downstream module then takes
+``PicoptSettings`` instead of ``AttrDict``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import re
+    from pathlib import Path
+
+
+__all__ = ("ComputedSettings", "IgnorePatterns", "PicoptSettings")
+
+
+@dataclass(frozen=True, slots=True)
+class IgnorePatterns:
+    """
+    Compiled ignore regexps populated by ``_set_ignore``.
+
+    Each pattern may be ``None`` when the user provided no ``ignore``
+    list and ``ignore_defaults=False``.
+    """
+
+    case: re.Pattern[str] | None
+    ignore_case: re.Pattern[str] | None
+
+
+@dataclass(frozen=True, slots=True)
+class ComputedSettings:
+    """
+    Computed-at-startup state that downstream code reads off the config.
+
+    - ``handler_stages`` is filled by :class:`ConfigHandlers` after probing
+      each handler's PIPELINE; absence of a handler-class key signals
+      "no available pipeline" to the routing layer. Typed as ``dict[Any, Any]``
+      to avoid an import cycle with ``picopt.plugins.base``; consumers know
+      the concrete shape via local ``cast``-style usage.
+    - ``ignore`` is filled by ``_set_ignore`` from the user's ``ignore``
+      list plus ``ignore_defaults``.
+    """
+
+    handler_stages: dict[Any, Any]
+    ignore: IgnorePatterns
+
+
+@dataclass(frozen=True, slots=True)
+class PicoptSettings:
+    """
+    Validated picopt runtime config.
+
+    Built once by :meth:`PicoptConfig.get_config` from the confuse
+    ``MappingTemplate`` output; consumed by every downstream module.
+    Field types match the runtime types confuse produces; ``Sequence(...)``
+    template entries become ``tuple[X, ...]`` since the dataclass is frozen.
+    """
+
+    # User-facing scalar options
+    bigger: bool
+    dry_run: bool
+    fail_fast: bool
+    fail_fast_container: bool
+    ignore_defaults: bool
+    jobs: int
+    keep_metadata: bool
+    list_only: bool
+    near_lossless: bool
+    png_max: bool
+    preserve: bool
+    recurse: bool
+    symlinks: bool
+    timestamps: bool
+    timestamps_check_config: bool
+    timestamps_ignore_archive_entry_mtimes: bool
+    verbose: int
+
+    # Sequences
+    disable_programs: tuple[str, ...]
+    formats: tuple[str, ...]
+    ignore: tuple[str, ...]
+    paths: tuple[Path, ...]
+
+    # Optional
+    after: float | None
+    convert_to: tuple[str, ...] | None
+    extra_formats: tuple[str, ...] | None
+
+    # Computed (populated by config-time helpers)
+    computed: ComputedSettings

--- a/picopt/path.py
+++ b/picopt/path.py
@@ -7,11 +7,11 @@ from tarfile import TarInfo
 from typing import cast
 from zipfile import ZipInfo
 
-from confuse import AttrDict
 from py7zr.py7zr import FileInfo as SevenZipInfo
 from rarfile import RarInfo
 
 from picopt.archiveinfo import ArchiveInfo
+from picopt.config.settings import PicoptSettings
 
 _CONTAINER_PATH_DELIMITER = ":"
 _LOWERCASE_TESTNAME = ".picopt_case_sensitive_test"
@@ -33,11 +33,11 @@ def is_path_case_sensitive(dirpath: Path) -> bool:
     return result
 
 
-def is_path_ignored(config: AttrDict, path: Path, *, ignore_case: bool) -> bool:
+def is_path_ignored(config: PicoptSettings, path: Path, *, ignore_case: bool) -> bool:
     """Match path against the ignore regexp."""
-    ignore = config.computed.ignore
-    ignore = ignore.ignore_case if ignore_case else ignore.case
-    return ignore and bool(ignore.search(str(path)))
+    patterns = config.computed.ignore
+    ignore = patterns.ignore_case if ignore_case else patterns.case
+    return ignore is not None and bool(ignore.search(str(path)))
 
 
 class PathInfo:

--- a/picopt/plugins/base/container.py
+++ b/picopt/plugins/base/container.py
@@ -35,9 +35,9 @@ from picopt.plugins.base.handler import Handler
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-    from confuse import AttrDict
     from treestamps import Grovestamps
 
+    from picopt.config.settings import PicoptSettings
     from picopt.path import PathInfo
     from picopt.report import ReportStats
     from picopt.walk.skip import WalkSkipper
@@ -61,7 +61,7 @@ class ContainerHandler(Handler, ABC):
         """Initialize instance vars."""
         super().__init__(*args, **kwargs)
         # Config gets mutated for pickling protection during repack.
-        self.config: AttrDict = copy(self.config)
+        self.config: PicoptSettings = copy(self.config)
         self._timestamps: Grovestamps | None = timestamps
         self.repack_handler_class: type[ContainerHandler] | None = repack_handler_class
         # Lazy import to avoid a cycle (walk.skip imports nothing of ours).

--- a/picopt/plugins/base/handler.py
+++ b/picopt/plugins/base/handler.py
@@ -31,8 +31,7 @@ from picopt.plugins.base.format import FileFormat
 from picopt.report import ReportStats
 
 if TYPE_CHECKING:
-    from confuse.templates import AttrDict
-
+    from picopt.config.settings import PicoptSettings
     from picopt.plugins.base.tool import Tool
 
 # Used by working-path construction for nested-container scratch files.
@@ -69,12 +68,12 @@ class Handler(ABC):
 
     def __init__(
         self,
-        config: AttrDict,
+        config: PicoptSettings,
         path_info: PathInfo,
         input_file_format: FileFormat,
     ) -> None:
         """Initialize handler state."""
-        self.config: AttrDict = config
+        self.config: PicoptSettings = config
         self.path_info: PathInfo = path_info
 
         # Paths

--- a/picopt/report.py
+++ b/picopt/report.py
@@ -10,8 +10,7 @@ from humanize import naturalsize
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from confuse import AttrDict
-
+    from picopt.config.settings import PicoptSettings
     from picopt.path import PathInfo
 
 
@@ -28,7 +27,7 @@ class ReportStats:
         bytes_out: int = 0,
         exc: BaseException | None = None,
         data: bytes = b"",
-        config: AttrDict | None = None,
+        config: PicoptSettings | None = None,
         path_info: PathInfo | None = None,
         converted: bool = False,
         changed: bool = False,

--- a/picopt/walk/handler_factory.py
+++ b/picopt/walk/handler_factory.py
@@ -42,9 +42,9 @@ from picopt.walk.detect_format import detect_format
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from confuse.templates import AttrDict
     from treestamps import Grovestamps
 
+    from picopt.config.settings import PicoptSettings
     from picopt.log.reporter import Reporter
     from picopt.path import PathInfo
     from picopt.plugins.base.format import FileFormat
@@ -53,9 +53,9 @@ if TYPE_CHECKING:
 class HandlerFactory:
     """Handler factory for creating format-appropriate handlers."""
 
-    def __init__(self, config: AttrDict, reporter: Reporter) -> None:
+    def __init__(self, config: PicoptSettings, reporter: Reporter) -> None:
         """Initialize with config and reporter."""
-        self._config: AttrDict = config
+        self._config: PicoptSettings = config
         self._reporter: Reporter = reporter
 
     def _lookup_route(
@@ -249,7 +249,7 @@ class HandlerFactory:
 
     @staticmethod
     def create_repack_handler(
-        config: AttrDict,
+        config: PicoptSettings,
         unpack_handler: ContainerHandler,
     ) -> ContainerHandler:
         """Return a handler to repack the container using the optimized contents."""

--- a/picopt/walk/legacy_timestamps.py
+++ b/picopt/walk/legacy_timestamps.py
@@ -1,11 +1,17 @@
 """import picopt 2.0 timestamps to Treestamps."""
 
-from pathlib import Path
+from __future__ import annotations
 
-from confuse.templates import AttrDict
-from treestamps import Treestamps
+from typing import TYPE_CHECKING
 
 from picopt.path import is_path_case_sensitive, is_path_ignored
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from treestamps import Treestamps
+
+    from picopt.config.settings import PicoptSettings
 
 OLD_TIMESTAMPS_NAME = ".picopt_timestamp"
 
@@ -55,9 +61,9 @@ class OldTimestamps:
         self._import_old_parent_timestamps()
         self._import_old_child_timestamps()
 
-    def __init__(self, config: AttrDict, timestamps: Treestamps) -> None:
+    def __init__(self, config: PicoptSettings, timestamps: Treestamps) -> None:
         """Hold new timestamp object."""
-        self._config: AttrDict = config
+        self._config: PicoptSettings = config
         self._timestamps: Treestamps = timestamps
         self._root_dir: Path = self._timestamps.root_dir
         self._ignore_case: bool = is_path_case_sensitive(self._root_dir)

--- a/picopt/walk/scheduler.py
+++ b/picopt/walk/scheduler.py
@@ -40,9 +40,9 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
-    from confuse.templates import AttrDict
     from treestamps import Grovestamps
 
+    from picopt.config.settings import PicoptSettings
     from picopt.log.reporter import Reporter
     from picopt.path import PathInfo
     from picopt.plugins.base import ContainerHandler, ImageHandler
@@ -213,12 +213,14 @@ class Scheduler:
     def __init__(
         self,
         *,
-        config: AttrDict,
+        config: PicoptSettings,
         executor: ProcessPoolExecutor,
         timestamps: Grovestamps | None,
         reporter: Reporter,
         max_workers: int,
-        create_repack_handler: Callable[[AttrDict, ContainerHandler], ContainerHandler],
+        create_repack_handler: Callable[
+            [PicoptSettings, ContainerHandler], ContainerHandler
+        ],
         child_enqueue_callback: Callable[
             [Scheduler, ContainerNode, list[PathInfo]], None
         ],

--- a/picopt/walk/skip.py
+++ b/picopt/walk/skip.py
@@ -15,9 +15,9 @@ from picopt.walk.legacy_timestamps import OLD_TIMESTAMPS_NAME
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from confuse import AttrDict
     from treestamps import Grovestamps
 
+    from picopt.config.settings import PicoptSettings
     from picopt.log.reporter import Reporter
 
 
@@ -30,14 +30,14 @@ class WalkSkipper:
 
     def __init__(
         self,
-        config: AttrDict,
+        config: PicoptSettings,
         reporter: Reporter,
         timestamps: Grovestamps | None = None,
         *,
         in_archive: bool = False,
     ) -> None:
         """Initialize."""
-        self._config: AttrDict = config
+        self._config: PicoptSettings = config
         self._timestamps: Grovestamps | None = timestamps
         self._in_archive: bool = in_archive
         self._reporter: Reporter = reporter

--- a/picopt/walk/walk.py
+++ b/picopt/walk/walk.py
@@ -28,7 +28,7 @@ from picopt.walk.scheduler import ContainerNode, OptimizeLeafJob, Scheduler
 from picopt.walk.skip import WalkSkipper
 
 if TYPE_CHECKING:
-    from confuse.templates import AttrDict
+    from picopt.config.settings import PicoptSettings
 
 
 class Walk:
@@ -52,9 +52,9 @@ class Walk:
             raise PicoptError(msg)
         return tuple(top_paths)
 
-    def __init__(self, config: AttrDict) -> None:
+    def __init__(self, config: PicoptSettings) -> None:
         """Initialize."""
-        self._config: AttrDict = config
+        self._config: PicoptSettings = config
         self._top_paths: tuple[Path, ...] = self._create_top_paths()
         self._stats: Stats = Stats(
             timestamps_active=bool(config.timestamps or config.after),
@@ -75,6 +75,13 @@ class Walk:
         """Init timestamps."""
         if not self._config.timestamps:
             return
+        # Treestamps filters program_config by program_config_keys; build a
+        # shallow Mapping with only those keys so we don't have to serialize
+        # the whole frozen dataclass (especially the computed sub-fields,
+        # which carry re.Pattern objects and class-keyed dicts).
+        program_config = {
+            key: getattr(self._config, key) for key in TIMESTAMPS_CONFIG_KEYS
+        }
         config = GrovestampsConfig(
             paths=self._top_paths,
             program_name=PROGRAM_NAME,
@@ -82,7 +89,7 @@ class Walk:
             symlinks=self._config.symlinks,
             ignore=self._config.ignore,
             check_config=self._config.timestamps_check_config,
-            program_config=self._config,
+            program_config=program_config,
             program_config_keys=TIMESTAMPS_CONFIG_KEYS,
         )
         self._timestamps = Grovestamps(config)
@@ -98,7 +105,7 @@ class Walk:
         if not self._timestamps:
             return
         if dumped := self._timestamps.dumpf():
-            roots = ", ".join(dumped)
+            roots = ", ".join(str(p) for p in dumped)
             logger.info(f"Dumped timestamps for: {roots}")
 
     def _enqueue_children(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "confuse~=2.1.0,<2.2.0",
+  "confuse~=2.2.0",
   "defusedxml>=0.7,<1.0",
   "filetype~=1.2",
   "humanize~=4.12",

--- a/uv.lock
+++ b/uv.lock
@@ -589,14 +589,14 @@ wheels = [
 
 [[package]]
 name = "confuse"
-version = "2.1.0"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/01/7d24e53986959b6148da5d0ffbce3e02e844110ac126bb42f46cad645ec9/confuse-2.1.0.tar.gz", hash = "sha256:abb9674a99c7a6efaef84e2fc84403ecd2dd304503073ff76ea18ed4176e218d", size = 22748, upload-time = "2025-10-27T10:22:01.251Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/a6/444c7376439851ce1d07932f88b707910d4605466d1c313621943c738112/confuse-2.2.0.tar.gz", hash = "sha256:35c1b53e81be125f441bee535130559c935917b26aeaa61289010cd1f55c2b9e", size = 52496, upload-time = "2026-01-28T10:40:16.042Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/6a/60e8d4a0e48559ff05aa7c9c65449c3a29c32ffe9f0690dc94b526c73c1f/confuse-2.1.0-py3-none-any.whl", hash = "sha256:502be1299aa6bf7c48f7719f56795720c073fb28550c0c7a37394366c9d30316", size = 25049, upload-time = "2025-10-27T10:22:00.08Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5d/a1333543a1b40fcbb08830330f6ea7bc7a3bda387a7a0c2bead534f5c01f/confuse-2.2.0-py3-none-any.whl", hash = "sha256:470c6aa1a5008c8d740267f2ad574e3a715b6dd873c1e5f8778b7f7abb954722", size = 27904, upload-time = "2026-01-28T10:40:14.508Z" },
 ]
 
 [[package]]
@@ -1660,7 +1660,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "confuse", specifier = "~=2.1.0,<2.2.0" },
+    { name = "confuse", specifier = "~=2.2.0" },
     { name = "defusedxml", specifier = ">=0.7,<1.0" },
     { name = "filetype", specifier = "~=1.2" },
     { name = "humanize", specifier = "~=4.12" },


### PR DESCRIPTION
## Summary

Confuse 2.2.0 made `AttrDict` a proper parameterized generic. An unparameterized `AttrDict` now resolves to `AttrDict[str, object]`, so every downstream attribute read returns `object` and stops type-checking — `bool(cfg.flag)`, `int(cfg.jobs)`, `cfg.paths` flowing into `Iterable[str]`, etc. We saw ~31 `basedpyright` errors after bumping the pin, all rooted at AttrDict consumers.

This is not a confuse bug — 2.1.0's implicit `Any` was hiding real schema mismatches. The honest fix is to stop passing `AttrDict` around as if it were a typed config object. Confuse still does YAML / env / CLI parsing, type coercion, validation; the validated result is converted into a typed frozen dataclass once, and every downstream module consumes the dataclass.

## Changes

- **`picopt/config/settings.py` (new)**: `PicoptSettings` and nested `ComputedSettings` / `IgnorePatterns` frozen dataclasses mirroring the existing `MappingTemplate` schema. `Sequence(...)` fields become `tuple[X, ...]` since the dataclass is frozen.
- **`picopt/config/__init__.py`**: `PicoptConfig.get_config` now returns `PicoptSettings`. New `_settings_from_attrdict` (typed `Any`) does the one-time field-by-field copy — the conversion *is* the schema escape hatch.
- **All consumers** (`picopt/path.py`, `picopt/report.py`, `picopt/walk/*`, `picopt/plugins/base/{handler,container}.py`) replace `from confuse(.templates) import AttrDict` with `from picopt.config.settings import PicoptSettings`.
- **`Walk._init_timestamps`** builds a shallow `Mapping[str, Any]` for Grovestamps' `program_config=` so we don't have to serialize the whole dataclass (the `computed` sub-fields carry `re.Pattern` and class-keyed `dict` objects that wouldn't round-trip).
- **`is_path_ignored`** switches from `ignore and bool(...)` to `ignore is not None and bool(...)` — return type is honestly `bool` now.
- **`Walk._dump_timestamps`** joins `dumpf` paths via `str(p)` since treestamps returns `tuple[Path, ...]`.
- **pyproject pin**: `confuse~=2.1.0,<2.2.0` → `confuse~=2.2.0`.

`handler_stages` in `ComputedSettings` is typed `dict[Any, Any]` to avoid an import cycle between `picopt.config.settings` and `picopt.plugins.base`. The few consumers know its concrete shape.

## Test plan

- [x] `uv run ruff check picopt/` — clean
- [x] `uv run basedpyright picopt/` — 0 errors (was 31), 13 stylistic warnings
- [x] `uv run pytest --deselect tests/test_timestamps.py::TestTimestamps::test_timestamp_parents` — 149 passed (deselected test is a pre-existing treestamps v4 regression, unrelated; tracked by https://github.com/ajslater/treestamps/pull/58)
- [x] `uv run complexipy picopt/` — no functions over 15
- [x] `uv run radon cc picopt/config/__init__.py` — all A/B grade
- [x] CLI smoke: `picopt -v file.jpg` and `PICOPT_BIGGER=true picopt -vvb file.jpg` both layer config correctly and emit the expected output

## Reference

Derived from the proto-plan at `proto-plan-confuse-2.2.0-migration.md`; same shape as the nudebomb migration referenced therein.

🤖 Generated with [Claude Code](https://claude.com/claude-code)