### PR TITLE
Drop dead isinstance check; split Scheduler._submit_ready_job

### DIFF
--- a/picopt/config/__init__.py
+++ b/picopt/config/__init__.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING, Any
 
 from confuse import Configuration, MappingTemplate
 from confuse.templates import (
-    AttrDict,
     Choice,
     Integer,
     Optional,
@@ -214,9 +213,6 @@ class PicoptConfig(ConfigHandlers):
         self._set_timestamps(config_program)
         self.set_format_handler_map(config_program)
         ad = config.get(_build_template())
-        if not isinstance(ad, AttrDict):
-            msg = f"Expected AttrDict from confuse, got {type(ad).__name__}"
-            raise TypeError(msg)
         return _settings_from_attrdict(ad.picopt)
 
 

--- a/picopt/walk/scheduler.py
+++ b/picopt/walk/scheduler.py
@@ -339,20 +339,25 @@ class Scheduler:
             + len(self._inflight_repack)
         )
 
-    def _submit_ready_job(self) -> None:
-        """Pop and submit one job from the ready dequeue."""
-        job, node = self._ready.popleft()
-        # Skip jobs whose owning node got cancelled while they were queued.
-        if node is not None and node.state is NodeState.CANCELLED:
-            match job:
-                case UnpackJob() | RepackJob():
-                    # node's own job — the cancel walk already decremented
-                    # the parent counter, nothing to do.
-                    pass
-                case _:
-                    node.pending = max(0, node.pending - 1)
-            return
-        fut = self._executor.submit(job.run)
+    @staticmethod
+    def _drop_cancelled_ready_job(job: Job, node: ContainerNode) -> None:
+        """
+        Decrement parent pending counter for a leaf of a cancelled subtree.
+
+        UnpackJob/RepackJob jobs belong to ``node`` itself; the cancel walk
+        already decremented the parent's pending counter for them, so they
+        need no further bookkeeping.
+        """
+        match job:
+            case UnpackJob() | RepackJob():
+                pass
+            case _:
+                node.pending = max(0, node.pending - 1)
+
+    def _track_submitted_job(
+        self, fut: Future, job: Job, node: ContainerNode | None
+    ) -> None:
+        """Record an in-flight future under the right map and update state."""
         match job:
             case UnpackJob():
                 assert node is not None
@@ -366,6 +371,16 @@ class Scheduler:
                 assert node is not None
                 node.state = NodeState.REPACKING
                 self._inflight_repack[fut] = node
+
+    def _submit_ready_job(self) -> None:
+        """Pop and submit one job from the ready dequeue."""
+        job, node = self._ready.popleft()
+        # Skip jobs whose owning node got cancelled while they were queued.
+        if node is not None and node.state is NodeState.CANCELLED:
+            self._drop_cancelled_ready_job(job, node)
+            return
+        fut = self._executor.submit(job.run)
+        self._track_submitted_job(fut, job, node)
 
     def _submit_ready(self) -> None:
         """Submit ready jobs up to the backpressure cap."""


### PR DESCRIPTION
## Summary

Two warnings flagged by \`make typecheck complexity\`:

### `picopt/config/__init__.py`
Confuse 2.2.0 already types \`config.get(MappingTemplate)\` as \`AttrDict[str, object]\`, so the defensive \`isinstance(ad, AttrDict)\` check after it was statically always-true:

\`\`\`
warning: Unnecessary isinstance call; "AttrDict[str, object]" is always an instance of "AttrDict[Unknown, Unknown]" (reportUnnecessaryIsInstance)
\`\`\`

Dropped the check and the now-unused \`AttrDict\` import.

### `picopt/walk/scheduler.py`
\`Scheduler._submit_ready_job\` was rank C in radon. Split into three smaller pieces, each rank A/B:

- \`_drop_cancelled_ready_job\` (staticmethod) — counter cleanup for a leaf of a cancelled subtree (\`UnpackJob\`/\`RepackJob\` skip; only leaf jobs decrement the parent counter, since the cancel walk already decremented for node-owned jobs).
- \`_track_submitted_job\` — record an in-flight future under the right map and update node state.
- \`_submit_ready_job\` — orchestrate: pop, cancelled-skip, submit, track.

Behavior unchanged.

## Verification

- [x] \`make typecheck\` — \`0 errors, 0 warnings, 0 notes\`
- [x] \`make complexity\` — no findings (was rank C on \`_submit_ready_job\`)
- [x] \`uv run ruff check picopt/\` — clean
- [x] \`uv run pytest\` — 150 passed, 6 skipped (the previously-broken \`test_timestamp_parents\` now passes thanks to the merged treestamps 4.0.2 fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)