### PR TITLE
Format argparse help with rich-argparse

### DIFF
--- a/picopt/cli.py
+++ b/picopt/cli.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
+import re
 import sys
 import traceback
-from argparse import Action, ArgumentParser, Namespace, RawDescriptionHelpFormatter
+from argparse import Action, ArgumentParser, Namespace
 from functools import cache
 from importlib.metadata import PackageNotFoundError, version
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from confuse.exceptions import ConfigError
 from loguru import logger
-from rich.console import Console
+from rich_argparse import RawDescriptionRichHelpFormatter
 from typing_extensions import override
 
 from picopt import PROGRAM_NAME
@@ -141,21 +142,44 @@ CHAR_KEY_LABELS: tuple[tuple[str, str], ...] = (
 
 
 def get_dot_color_key() -> str:
-    """Create the progress char legend for the help epilogue."""
-    console = Console(record=True, force_terminal=True, no_color=False)
-    console.begin_capture()
-    console.print("[bold]Progress char key:[/bold]")
+    """
+    Build the progress-char legend + doctor-mode hint for the help epilog.
+
+    Returns Rich markup; ``RawDescriptionRichHelpFormatter`` parses it
+    against the formatter's ``styles`` theme, so ``[argparse.prog]`` and
+    ``[argparse.args]`` resolve to the same colors used elsewhere in
+    the rendered help.
+    """
+    lines = ["[argparse.groups]Progress char key:[/argparse.groups]"]
     for kind, label in CHAR_KEY_LABELS:
         mark = MARKS[kind]
-        console.print(f"\t[{mark.style}]{mark.char}[/{mark.style}]  {label}")
-    console.print()
-    console.print("[bold blue]doctor mode:[/bold blue]")
-    doctor_mode = (
-        f" [bright_magenta]{PROGRAM_NAME}[/bright_magenta] "
-        "[bright_green]doctor[/bright_green]\t\tDoctor mode shows available tools."
+        lines.append(f"\t[{mark.style}]{mark.char}[/{mark.style}]  {label}")
+    lines.extend(
+        (
+            "",
+            "[argparse.groups]doctor mode:[/argparse.groups]",
+            f" [argparse.prog]{PROGRAM_NAME}[/argparse.prog]"
+            " [argparse.args]doctor[/argparse.args]"
+            "\t\tDoctor mode shows available tools.",
+        )
     )
-    console.print(doctor_mode)
-    return console.end_capture()
+    return "\n".join(lines)
+
+
+class PicoptHelpFormatter(RawDescriptionRichHelpFormatter):
+    """
+    Rich help formatter that highlights picopt format names.
+
+    Format strings mentioned in help text (e.g. ``PNG``, ``ZIP``,
+    ``WEBP``) are colorized with the same style as the metavars they
+    correspond to (``FORMATS``, ``EXTRA_FORMATS``, ...), so the help
+    reads coherently.
+    """
+
+    highlights: ClassVar[list[str]] = [
+        *RawDescriptionRichHelpFormatter.highlights,
+        rf"\b(?P<metavar>{'|'.join(re.escape(f) for f in registry.all_format_strs())})\b",
+    ]
 
 
 def get_arguments(params: tuple[str, ...] | None = None) -> Namespace:
@@ -170,7 +194,7 @@ def get_arguments(params: tuple[str, ...] | None = None) -> Namespace:
     parser = ArgumentParser(
         description=description,
         epilog=epilog,
-        formatter_class=RawDescriptionHelpFormatter,
+        formatter_class=PicoptHelpFormatter,
     )
     parser.add_argument(
         "-r",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "python-dateutil~=2.8",
   "rarfile~=4.0",
   "rich~=15.0",
+  "rich-argparse~=1.8",
   "ruamel-yaml>=0.18,<1.0",
   "treestamps~=4.0.1",
   "typing-extensions~=4.13",

--- a/uv.lock
+++ b/uv.lock
@@ -1603,6 +1603,7 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "rarfile" },
     { name = "rich" },
+    { name = "rich-argparse" },
     { name = "ruamel-yaml" },
     { name = "treestamps" },
     { name = "typing-extensions" },
@@ -1663,6 +1664,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = "~=2.8" },
     { name = "rarfile", specifier = "~=4.0" },
     { name = "rich", specifier = "~=15.0" },
+    { name = "rich-argparse", specifier = "~=1.8" },
     { name = "ruamel-yaml", specifier = ">=0.18,<1.0" },
     { name = "treestamps", specifier = "~=4.0.1" },
     { name = "typing-extensions", specifier = "~=4.13" },
@@ -2528,6 +2530,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-argparse"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/e5/1064c43203a357d668cd42435f7a15fe6af51512d85b2104fecb937aa861/rich_argparse-1.8.0.tar.gz", hash = "sha256:679df3d832fa94ad6e4bdb07ded088cd7ea2dddc58ae9b2b46346a40b06cbc0c", size = 38940, upload-time = "2026-05-01T15:18:43.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/35/1cceccc5fcb50fa2ed53e2aa278cd032f3902682a73e763fb1ac3be8e6fa/rich_argparse-1.8.0-py3-none-any.whl", hash = "sha256:d2a3ce7854654e2253c578763ab0a32f05016f23a55fadba7b9a91b6c0e92142", size = 25616, upload-time = "2026-05-01T15:18:42.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Switch picopt's CLI to `rich_argparse.RawDescriptionRichHelpFormatter` (via a `PicoptHelpFormatter` subclass) so `picopt --help` is colorized.
- Add one extra highlight regex matching every registered format string (`PNG`, `ZIP`, `WEBP`, `JPEG`, …) under the `metavar` named group, so format names mentioned inside help text share the color of their corresponding `FORMATS` / `EXTRA_FORMATS` / `CONVERT_TO` metavars. The default rich-argparse highlight already handles `--option` references in help text.
- Rewrite the dot-color-key / doctor-mode epilog as Rich markup instead of capturing ANSI from a `Console`. rich-argparse renders descriptions and epilogs through `console.use_theme(Theme(self.styles))`, so the epilog uses `[argparse.groups]`, `[argparse.prog]`, and `[argparse.args]` to keep the section header, program name, and `doctor` subcommand visually consistent with the rest of the rendered help.
- The progress-char dots themselves still pull `char` + `style` straight from `picopt.log.styles.MARKS`, so the legend keeps its existing per-outcome colors.

## Why

The previous epilog rendered Rich markup through a captured `Console`, then handed argparse a string of raw ANSI escape codes. That worked, but the rest of the help was uncolored, and there was no relationship between (e.g.) the `FORMATS` metavar color and the format names listed in the help text body. rich-argparse's `highlights` mechanism makes that link first-class.

## Notes for reviewers

- New runtime dependency: `rich-argparse~=1.8` (added to `pyproject.toml` / `uv.lock`).
- `from rich.console import Console` import is dropped from `picopt/cli.py` — `Console` was only used for the old ANSI-capture path.
- `PicoptHelpFormatter.highlights` is computed at class-definition time from `registry.all_format_strs()` (which is `@cache`'d), so there's no per-invocation cost.

## Test plan

- [x] `make lint` (clean)
- [x] `make ty` (clean)
- [x] `pytest` — 150 passed, 6 skipped
- [x] `picopt --help` rendered manually; format names in help text and the epilog headers/prog/subcommand all pick up the formatter theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)