### PR TITLE
Defer animated WebP duration extraction to handler

### DIFF
--- a/picopt/plugins/webp.py
+++ b/picopt/plugins/webp.py
@@ -636,9 +636,7 @@ class WebPMuxAnimatedLossless(WebPAnimatedLossless):
             msg = "No frames found — is this actually an animated WebP?"
             raise ValueError(msg)
 
-        self._durations = self.info.get("durations") or self._read_durations(
-            len(extracted)
-        )
+        self._durations = self._read_durations(len(extracted))
         self._do_repack = True
         self._walk_finish()
 

--- a/picopt/walk/detect_format.py
+++ b/picopt/walk/detect_format.py
@@ -31,8 +31,7 @@ from __future__ import annotations
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, BinaryIO
 
-from loguru import logger
-from PIL import Image, ImageSequence, UnidentifiedImageError
+from PIL import Image, UnidentifiedImageError
 
 from picopt import plugins as registry
 from picopt.pillow.webp_lossless import is_lossless as _webp_is_lossless
@@ -48,30 +47,8 @@ if TYPE_CHECKING:
 
 # PIL format-string constants. Hardcoded so this module doesn't have to
 # import the per-format PIL ImageFile subclasses just to read a string.
-_MPO_FORMAT_STR = "MPO"
 _TIFF_FORMAT_STR = "TIFF"
 _WEBP_FORMAT_STR = "WEBP"
-
-
-def _extract_animated_durations(image: ImageFile, info: dict[str, Any]):
-    durations = {}
-    if image.format == _MPO_FORMAT_STR:
-        return durations
-
-    # PIL frequently fails to populate per-frame durations on WebP
-    if image.format != _WEBP_FORMAT_STR and info.get("durations"):
-        return durations
-
-    try:
-        for frame_index, frame in enumerate(ImageSequence.Iterator(image), start=1):
-            duration = frame.info.get("duration", None)
-            if duration is not None:
-                durations[frame_index] = duration
-    except Exception as exc:
-        msg = "Error extracting animated frame duration"
-        logger.warning(msg)
-        logger.exception(exc)
-    return durations
 
 
 def _extract_image_info_from_image(
@@ -90,8 +67,6 @@ def _extract_image_info_from_image(
     info["animated"] = animated
     if animated and (n_frames := getattr(image, "n_frames", 0)):
         info["n_frames"] = n_frames
-        if durations := _extract_animated_durations(image, info):
-            info["durations"] = durations
     with suppress(AttributeError):
         info["mpinfo"] = image.mpinfo  # pyright: ignore[reportAttributeAccessIssue]  # ty: ignore[unresolved-attribute]
 


### PR DESCRIPTION
## Summary

- Removed `_extract_animated_durations` from `detect_format.py`, which iterated every frame of every animated image during format detection.
- Simplified `WebPMuxAnimatedLossless.walk` to always use its existing `_read_durations` (webpmux subprocess) fallback.

## Why

`info["durations"]` had exactly one consumer: `WebPMuxAnimatedLossless` at [`webp.py:639`](https://github.com/ajslater/picopt/blob/develop/picopt/plugins/webp.py#L639), which already had a `_read_durations()` fallback for when PIL's frame iteration was unreliable. The original comment in detect_format said "PIL frequently fails to populate per-frame durations on WebP" — meaning the webpmux subprocess is the more reliable source anyway.

Animated PNG/GIF handlers never used `info["durations"]`; they collect per-frame durations during their own `walk()` via `populate_frame_info` into `frame_info["duration"]`.

## Impact

Local microbenchmarks of `_extract_image_info` per file:

| File | Before | After | Speedup |
|------|--------|-------|---------|
| test_animated_png.png | 1586us | 145us | 10.9x |
| test_animated_gif.gif | 693us | 165us | 4.2x |
| test_animated_webp.webp | — | 66us | — |
| test_png.png (still) | 55us | 74us | (noise) |

Trade-off: `WebPMuxAnimatedLossless.walk()` always invokes one extra `webpmux -info` subprocess. Since `walk()` already runs many `webpmux -get frame N` invocations to extract each frame, this is negligible on the wall clock.

## Test plan

- [x] Existing `make test` suite passes (150 passed, 6 skipped).
- [x] Animated WebP roundtrip (`test_images_dir.py::test_animated_webp.webp`) covers the WebPMux duration path.
- [x] `make fix`, `make lint`, `make ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)