### PR TITLE
Single Image.open in _extract_image_info; read metadata before verify

### DIFF
--- a/picopt/walk/detect_format.py
+++ b/picopt/walk/detect_format.py
@@ -29,7 +29,7 @@ Two-phase dispatch:
 from __future__ import annotations
 
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, BinaryIO
+from typing import TYPE_CHECKING, Any
 
 from PIL import Image, UnidentifiedImageError
 
@@ -74,28 +74,17 @@ def _extract_image_info_from_image(
 def _extract_image_info(
     path_info: PathInfo, *, keep_metadata: bool
 ) -> tuple[str | None, dict[str, Any]]:
-    """
-    Get image format and info from a file via PIL.
-
-    PIL's ``verify()`` consumes the image; we have to open the file twice:
-    once to verify, then again to read the format and info.
-    """
+    """Get image format and info from a file via PIL."""
     image_format_str: str | None = None
     info: dict[str, Any] = {}
     try:
-        fp = path_info.path_or_buffer()
-        with Image.open(fp) as image:
-            image.verify()
-        image.close()  # animated images keep the fp open after the with-block
-        if isinstance(fp, BinaryIO):
-            fp.close()
-        fp = path_info.path_or_buffer()
-        with Image.open(fp) as image:
+        # Read metadata before verify(): for some Path-opened formats
+        # (notably GIF), PIL closes its internal fp during verify(), which
+        # then breaks lazy attrs like is_animated and n_frames.
+        with Image.open(path_info.path_or_buffer()) as image:
             image_format_str = image.format
             _extract_image_info_from_image(image, info, keep_metadata=keep_metadata)
-        image.close()
-        if isinstance(fp, BinaryIO):
-            fp.close()
+            image.verify()
     except UnidentifiedImageError:
         pass
     return image_format_str, info


### PR DESCRIPTION
## Summary

- `_extract_image_info` now uses a single `Image.open()` instead of two.
- Reads `format`, `info`, `is_animated`, `n_frames`, `mpinfo` *before* `image.verify()` instead of after.

## Why

The previous double-open existed because of this comment:

> PIL's `verify()` consumes the image; we have to open the file twice: once to verify, then again to read the format and info.

That is half-true on Pillow 12.x. `verify()` does not consume `.format` / `.info`, but for some Path-opened formats (notably GIF) PIL closes its internal fp during `verify()`, which then breaks lazy attrs like `is_animated` and `n_frames` (`ValueError: seek of closed file`).

Reordering — read first, verify last — keeps the integrity check intact (any corruption raises and propagates the same way as before) while collapsing to one open.

## Verified formats

Tested against the local corpus on Pillow 12.2: GIF (still + animated), TIFF (single + multi-frame), MPO, animated PNG, animated WebP, JPEG, BMP, PPM. All read correct `format`/`is_animated`/`n_frames`/`info` and `verify()` succeeds.

## Impact

`_extract_image_info` per-file (warm cache, microbenchmark, savings vary by format):

| File | Before | After |
|------|--------|-------|
| test_animated_gif.gif | 165us | 95us |
| test_animated_png.png | 145us | 113us |
| test_animated_webp.webp | 66us | 30us |
| test_png.png | 74us | 35us |

## Test plan

- [x] `make test` passes (150 passed, 6 skipped).
- [x] `make fix`, `make lint`, `make ty` clean.
- [x] Manual probe across 11 representative files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)